### PR TITLE
Update scaffolding and sorting on diagram

### DIFF
--- a/app/authorized/diagram/components/diagramClient.tsx
+++ b/app/authorized/diagram/components/diagramClient.tsx
@@ -38,7 +38,7 @@ export default function DiagramClient({
   const fetchData = useCallback(async () => {
     if (!jobInfo?.jobUid) return;
     setIsLoading(true);
-
+    
     const result = await getTraceDataAction(jobInfo.jobUid);
     if (result.success && result.data) {
       setRawEvents(result.data as TJob_Process_Messages[]);
@@ -57,7 +57,7 @@ export default function DiagramClient({
       s.add(e.from);
       s.add(e.to);
     });
-    return Array.from(s).sort();
+    return Array.from(s);
   }, [rawEvents]);
 
   const { plotData, layout, dynamicHeight } = useMemo(() => {

--- a/default_files/defaultMain.ts
+++ b/default_files/defaultMain.ts
@@ -1,5 +1,4 @@
-export const defaultMain = `
-package main
+export const defaultMain = `package main
 
 import (
 	"context"

--- a/default_files/defaultProtocol.ts
+++ b/default_files/defaultProtocol.ts
@@ -1,6 +1,5 @@
 export const defaultProtocol = `package shared
 
-
 // BaseMessage from DSNet, base your protocol on this struct.
 // type BaseMessage struct {
 // 		From string


### PR DESCRIPTION
This pull request introduces improvements to the default test setup logic, minor code formatting adjustments, and a small change to the diagram client component. The most significant change is a new retry mechanism for initializing peer readiness in the test environment, making the test setup more robust.

**Test harness improvements:**

* Added a retry loop in `TestMain` within `defaultTest.ts` to repeatedly check peer readiness, logging failures and waiting between attempts, instead of a single call. This helps ensure all peers are ready before tests run.
* Added imports for `log` and `time` packages in `defaultTest.ts` to support the new retry logic.

**Formatting and minor code changes:**

* Removed an unnecessary newline at the top of `defaultProtocol.ts` for cleaner formatting.
* Moved the `package main` declaration to the first line in `defaultMain.ts` for correct Go file formatting.

**Diagram client change:**

* Removed the sorting step when returning the array of nodes in the `DiagramClient` component, now returning nodes in their original order following the order the author set them in.